### PR TITLE
refactor: Replace system() with fork/exec for hook execution

### DIFF
--- a/src/utils/hooks.c
+++ b/src/utils/hooks.c
@@ -1,28 +1,56 @@
 #include "hooks.h"
 #include "utils.h"
+#include <errno.h>
+#include <stdio.h>
 #include <stdlib.h>
-#include <stdio.h> 
-#include <limits.h>
-#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 void run_hook_script(char *script_path) {
-  if (!script_path) {
+  if (!script_path)
+    return;
+
+  pid_t pid = fork();
+
+  if (pid == -1) {
+    logging(ERROR, "Failed to fork process for hook script: %s", script_path);
     return;
   }
 
-  char *command = malloc(strlen(script_path) + 20);
-  if (!command) {
-      logging(ERROR, "Failed to allocate memory for command");
-      return;
-  }
-  snprintf(command, strlen(script_path) + 20, "%s > /dev/null 2>&1", script_path);
+  if (pid == 0) {
+    // --- Child Process ---
+    // Redirect stdout and stderr to /dev/null
+    freopen("/dev/null", "w", stdout);
+    freopen("/dev/null", "w", stderr);
 
-  logging(INFO, "Running hook script: %s", script_path);
-  int result = system(command);
-  if (result == -1) {
-    logging(ERROR, "Failed to execute hook script.");
-  } else if (result != 0) {
-    logging(WARN, "Hook script exited with non-zero status: %d", result);
+    char *args[] = {script_path, NULL};
+    execvp(script_path, args);
+
+    // If execvp gets here, it failed. Check errno.
+    if (errno == EACCES) {
+      _exit(126); // Not executable
+    } else {
+      _exit(127); // Not found
+    }
+  } else {
+    // --- Parent Process ---
+    int status;
+    waitpid(pid, &status, 0);
+
+    if (WIFEXITED(status)) {
+      int exit_code = WEXITSTATUS(status);
+      if (exit_code == 0) {
+        logging(INFO, "Hook script '%s' ran successfully.", script_path);
+      } else if (exit_code == 126) {
+        logging(WARN, "Hook script '%s' is not executable.", script_path);
+      } else if (exit_code == 127) {
+        logging(WARN, "Hook script '%s' not found.", script_path);
+      } else {
+        logging(WARN, "Hook script '%s' exited with non-zero status: %d",
+                script_path, exit_code);
+      }
+    } else {
+      logging(ERROR, "Hook script '%s' terminated abnormally.", script_path);
+    }
   }
-  free(command);
 }


### PR DESCRIPTION
This pull request refactors the `run_hook_script` function to replace the insecure and inefficient `system()` call with a robust `fork()` and `execvp()` implementation.

This change significantly improves the security and reliability of how external hook scripts are executed.

---

### Key Improvements

- **Enhanced Security:**  
  Eliminates the possibility of shell injection vulnerabilities by avoiding the shell (`/bin/sh`) and passing the script path directly to `execvp`.

- **Improved Efficiency:**  
  Creates a new process directly with `fork()` instead of spawning an intermediate shell, which is more lightweight.

- **Precise Error Reporting:**  
  The new implementation provides much more granular and actionable error messages by checking the script's exit code and `errno`:
  - Logs a specific **WARN** if the script is not found (exit code `127`).
  - Logs a specific **WARN** if the script is found but not executable (exit code `126`).
  - Logs a **WARN** if the script runs but fails with its own non-zero exit code.

- **Cleaner Logging:**  
  The console output is now cleaner. A "success" message is only logged if the script runs and exits with a status of `0`, preventing premature or unnecessary log entries.

---

This refactor makes the hook execution system **more stable, secure, and developer-friendly**.
