### PR TITLE
chore: nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 .cache/
 asserts/
+result/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1753549186,
+        "narHash": "sha256-Znl7rzuxKg/Mdm6AhimcKynM7V3YeNDIcLjBuoBcmNs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "17f6bd177404d6d43017595c5264756764444ab8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,69 @@
+{
+  description = "CWAL - Blazing-fast pywal-like color palette generator written in C";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+    in {
+      packages.default = pkgs.stdenv.mkDerivation {
+        pname = "cwal";
+        version = "0.1.0";
+
+        src = ./.;
+
+        nativeBuildInputs = with pkgs; [
+          cmake
+          pkg-config
+        ];
+
+        buildInputs = with pkgs; [
+          imagemagick
+          libimagequant
+        ];
+
+        cmakeFlags = [
+          "-DCMAKE_BUILD_TYPE=Release"
+        ];
+
+        installPhase = ''
+          runHook preInstall
+
+          mkdir -p $out/bin
+          cp cwal $out/bin/
+
+          if [ -d ../templates ]; then
+            mkdir -p $out/share/cwal
+            cp -r ../templates $out/share/cwal/
+          fi
+
+          runHook postInstall
+        '';
+
+        meta = with pkgs.lib; {
+          description = "CWAL - Blazing-fast pywal-like color palette generator written in C";
+          license = licenses.gpl3;
+          platforms = platforms.linux;
+        };
+      };
+
+      devShells.default = pkgs.mkShell {
+        buildInputs = with pkgs; [
+          cmake
+          pkg-config
+          imagemagick
+          libimagequant
+          gdb
+          valgrind
+        ];
+      };
+    });
+}


### PR DESCRIPTION
## authors
@arinono

## issues
refs none 

## impl

Added a nix flake to build cwal with nix. Tested on `x86_64-linux` and `aarch64-linux`