### PR TITLE
Fix AUR package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ brew install imagemagick libimagequant luajit
 **Arch Linux (AUR)**
 
 ```bash
-yay -S cwal
+yay -S cwal-git
 # or
-paru -S cwal
+paru -S cwal-git
 ```
 
 **Homebrew**


### PR DESCRIPTION
There is no cwal package, only a cwal-git one.

See: 404 on https://aur.archlinux.org/packages/cwal
Exists: https://aur.archlinux.org/packages/cwal-git